### PR TITLE
Suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-Source codes from my "OpenGL in python" youtube tutorials.
+# Learn OpenGL in Python
+
+Source codes from my "OpenGL in python" youtube tutorials
+
+## Episodes
+
+* e01 : https://www.youtube.com/watch?v=LqPPvPKUfV4&t=0s
+
+## Requirements
+
+    pip install -r requirements.txt

--- a/ep01_glfw_window.py
+++ b/ep01_glfw_window.py
@@ -1,9 +1,19 @@
 import glfw
-
+from OpenGL.GL import *
 
 # initializing glfw library
 if not glfw.init():
     raise Exception("glfw can not be initialized!")
+
+# Configure the OpenGL context.
+# If we are planning to use anything above 2.1 we must at least
+# request a 3.3 core context to make this work across platforms.
+glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
+glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
+glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
+glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, True)
+# 4 MSAA is a good default with wide support
+glfw.window_hint(glfw.SAMPLES, 4)
 
 # creating the window
 window = glfw.create_window(1280, 720, "My OpenGL window", None, None)
@@ -13,16 +23,20 @@ if not window:
     glfw.terminate()
     raise Exception("glfw window can not be created!")
 
+# Query the actual framebuffer size so we can set the right viewport later
+# -> glViewport(0, 0, framebuffer_size[0], framebuffer_size[1])
+framebuffer_size = glfw.get_framebuffer_size(window)
+
 # set window's position
 glfw.set_window_pos(window, 400, 200)
 
 # make the context current
 glfw.make_context_current(window)
 
+
 # the main application loop
 while not glfw.window_should_close(window):
     glfw.poll_events()
-
     glfw.swap_buffers(window)
 
 # terminate glfw, free up allocated resources

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+glfw
+pyopengl


### PR DESCRIPTION
Some simple suggestions making things work on multiple platforms + info.

If you are planning to do a 3.3+ tutorial we have to request at least a 3.3 core forward compatible context or it won't work with drivers and platforms not supporting compatibility mode. OS X is one example. If only doing GL 2.1 we can drop the context configuration.


